### PR TITLE
Fix redirection after login

### DIFF
--- a/pages/assets/js/plugin.js
+++ b/pages/assets/js/plugin.js
@@ -5,7 +5,13 @@ $(document).ready(function() {
     var frm = $('#login-form');
     var redirectUri = $("meta[name='redirectUri']").attr('content');
     var clientId = $("meta[name='clientId']").attr('content');
-    $('<a class="btn btn-primary btn-sm bigger-110" href="https://accounts.google.com/o/oauth2/auth?response_type=code&redirect_uri=' + redirectUri + '&client_id=' + clientId + '&scope=https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&access_type=offline&approval_prompt=force&state=">Sign in with google</a>').appendTo(frm);
+    // (disabled) Send all the params
+    //var url = window.location.href
+    //var state = ( url.match(/\?(.+)$/) || [,''])[1];
+    // Send just the return param value
+    var urlParams = new URLSearchParams(window.location.search);
+    var state = urlParams.get('return') || '';
+    $('<a id="sign_with_google" class="btn btn-primary btn-sm bigger-110" href="https://accounts.google.com/o/oauth2/auth?response_type=code&redirect_uri=' + redirectUri + '&client_id=' + clientId + '&scope=https://www.googleapis.com/auth/userinfo.profile+https://www.googleapis.com/auth/userinfo.email&access_type=offline&prompt=consent&state=' + state + '">Sign in with google</a>').appendTo(frm);
 
     frm.children('#sign_with_google').on('click', function(){
         return false;

--- a/pages/redirect.php
+++ b/pages/redirect.php
@@ -60,5 +60,5 @@ user_reset_lost_password_in_progress_count_to_zero( $user_id );
 auth_set_cookies( $user_id, false );
 auth_set_tokens( $user_id );
 
-print_header_redirect( '../../../my_view_page.php' );
+print_header_redirect( '../../../index.php' );
 

--- a/pages/redirect.php
+++ b/pages/redirect.php
@@ -60,5 +60,13 @@ user_reset_lost_password_in_progress_count_to_zero( $user_id );
 auth_set_cookies( $user_id, false );
 auth_set_tokens( $user_id );
 
-print_header_redirect( '../../../index.php' );
+// Obtain the redicrect url from state param
+// Example: state=view.php?id=2222
+if (isset($_GET['state'])) {
+    $return_path = $_GET['state'];
+    $redirect_url = '../../../' . $return_path;
+} else {
+    $redirect_url = '../../../index.php';
+}
 
+print_header_redirect( $redirect_url );


### PR DESCRIPTION
The following PR fixes the issue #11 

Changes:
* Added redirection to a custom page after login process [1]
* Changed the default home page from `my_view.php`to `index.php` [2]


[1]
If you want to go to a custom page (i.e. view.php?id=22), and you are not yet logged in, the plugin will now redirect you to that page after the login process.

[2]
The home page should be `index.php`, which will redirect you by default to `my_view.php`. You can change that in your settings (i.e.  `$g_default_home_page='bug_report_page.php'` ).